### PR TITLE
Check for developer role

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 const express = require('express');
 const app = express();
 const bodyParser = require('body-parser');
+require('dotenv').config();
 const PORT = process.env.PORT || 5000;
 const isDevelopment = process.env.DEVELOPMENT;
+const devRoleId = process.env.DEV_ROLE; 
 const KARAS_ID = 356283233207320577;
 
 // establish discordjs client
@@ -52,8 +54,8 @@ bot.on('debug', (info) => {
 bot.on('message', message => {
 	const author = message.author;
 	const {username} = author;
-
-	if (isDevelopment && username !== 'Zarathustra') {
+	
+	if (isDevelopment && !message.member.roles.get(devRoleId)) {
 		return;
 	}
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const bodyParser = require('body-parser');
 require('dotenv').config();
 const PORT = process.env.PORT || 5000;
 const isDevelopment = process.env.DEVELOPMENT;
-const devRoleId = process.env.DEV_ROLE; 
+const devRoleName = 'инженер ЭВМ'; 
 const KARAS_ID = 356283233207320577;
 
 // establish discordjs client
@@ -55,7 +55,7 @@ bot.on('message', message => {
 	const author = message.author;
 	const {username} = author;
 	
-	if (isDevelopment && !message.member.roles.get(devRoleId)) {
+	if (isDevelopment && !message.member.roles.find("name", devRoleName)) {
 		return;
 	}
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "body-parser": "^1.18.3",
     "discord.js": "^11.3.2",
+    "dotenv": "^8.2.0",
     "express": "^4.16.3",
     "giphy-js-sdk-core": "^1.0.5",
     "googleapis": "^32.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -290,6 +290,11 @@ discord.js@^11.3.2:
     tweetnacl "^1.0.0"
     ws "^6.0.0"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"


### PR DESCRIPTION
When running in development mode, check for developer role ID.
Role ID must be specified in the process.env variable.